### PR TITLE
upgrade to newer version of libv8 gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -16,7 +16,7 @@ group :assets do
   gem 'jquery-rails'
   gem 'twitter-bootstrap-rails'
 
-  gem 'libv8', '3.3.10.2'
+  gem 'libv8', '3.3.10.4'
   gem 'therubyracer', '~> 0.10.0', :platforms => :ruby
 
   gem 'uglifier', '>= 1.0.3'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -58,7 +58,7 @@ GEM
       railties (>= 3.1.0, < 5.0)
       thor (~> 0.14)
     json (1.7.6)
-    libv8 (3.3.10.2)
+    libv8 (3.3.10.4)
     mail (2.4.4)
       i18n (>= 0.4.0)
       mime-types (~> 1.16)
@@ -138,7 +138,7 @@ PLATFORMS
 DEPENDENCIES
   coffee-rails (~> 3.2.1)
   jquery-rails
-  libv8 (= 3.3.10.2)
+  libv8 (= 3.3.10.4)
   minitest-spec-rails
   rails (= 3.2.10)
   resque!


### PR DESCRIPTION
I had a lot of trouble installing `therubyracer` gem on Mac OSX mountain Lion (10.8.2).

After a lot of digging around, this combination of the `libv8` made it possible to install the `therubyracer` gem. This [SO answer](http://stackoverflow.com/a/8127559) also supports the idea.
